### PR TITLE
fix: add solhint config

### DIFF
--- a/apps/contracts/.solhint.json
+++ b/apps/contracts/.solhint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "solhint:default"
+}

--- a/apps/contracts/.solhint.json
+++ b/apps/contracts/.solhint.json
@@ -1,3 +1,3 @@
 {
-  "extends": "solhint:default"
+    "extends": "solhint:default"
 }


### PR DESCRIPTION
## Description

`yarn lint` in `apps/contracts` fails with `Failed to load a solhint's config file.` . This PR adds the minimal config file (equivalent to running `npx solhint --init` )


## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
