### PR TITLE
refactor: automatically download snark artifacts 

### DIFF
--- a/apps/contracts/package.json
+++ b/apps/contracts/package.json
@@ -8,7 +8,7 @@
         "compile": "hardhat compile",
         "download:snark-artifacts": "hardhat run scripts/download-snark-artifacts.ts",
         "deploy": "yarn compile && hardhat deploy",
-        "test": "hardhat test",
+        "test": "hardhat run scripts/download-snark-artifacts.ts && hardhat test",
         "test:report-gas": "REPORT_GAS=true hardhat test",
         "test:coverage": "hardhat coverage",
         "typechain": "hardhat typechain",


### PR DESCRIPTION
## Description

Automatically download snark artifacts before testing smart contracts.

## Related Issue

Closes #23 

## Does this introduce a breaking change?

-   [ ] Yes
-   [x] No
