### PR TITLE
Update Feedback.sol

### DIFF
--- a/apps/contracts/contracts/Feedback.sol
+++ b/apps/contracts/contracts/Feedback.sol
@@ -25,6 +25,6 @@ contract Feedback {
         uint256 nullifierHash,
         uint256[8] calldata proof
     ) external {
-        semaphore.verifyProof(groupId, merkleTreeRoot, feedback, nullifierHash, groupId, proof);
+        semaphore.verifyProof(groupId, merkleTreeRoot, feedback, nullifierHash, proof);
     }
 }


### PR DESCRIPTION
## Description

### BUG in Feedback.sol contract

Apparently in the Feedback.sol file 

In the method sendFeedback there is a call to the  semaphore.verifyProof(groupId, merkleTreeRoot, feedback, nullifierHash, groupId, proof);


there is a extra parameter passed called groupId again which is  I believe is causing errors when I try to interact with it 

I looked into the interface and found the verifyProof method as this 

function verifyProof(
        uint256 groupId,
        uint256 merkleTreeRoot,
        uint256 signal,
        uint256 nullifierHash,
        uint256 externalNullifier,
        uint256[8] calldata proof
    ) external;

so in my recent commit I just removed the extra parameter(groupId) which was being passed into the verify.Proof() method




## Does this introduce a breaking change?
-   No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
