### PR TITLE
fix : reversing groups and pages list to make recent ones appear first

### DIFF
--- a/apps/web-app/src/app/group/page.tsx
+++ b/apps/web-app/src/app/group/page.tsx
@@ -133,7 +133,6 @@ export default function GroupsPage() {
             {_users.length > 0 && (
                 <VStack spacing="3" pb="3" align="left" maxHeight="300px" overflowY="scroll">
                     {users.map((user, i) =>(
-                      
                         <HStack key={i} pb="3" borderBottomWidth={i < _users.length - 1 ? 1 : 0} whiteSpace="nowrap">
                             <Text textOverflow="ellipsis" overflow="hidden">
                                 {_identity?.commitment === user ? <b>{user}</b> : user}

--- a/apps/web-app/src/app/group/page.tsx
+++ b/apps/web-app/src/app/group/page.tsx
@@ -23,7 +23,7 @@ export default function GroupsPage() {
         }
     }, [_users, setLog])
 
-    const users = [..._users].reverse();
+    const users = useMemo(() => [..._users].reverse(), [_users])
 
     const joinGroup = useCallback(async () => {
         if (!_identity) {
@@ -132,13 +132,12 @@ export default function GroupsPage() {
 
             {_users.length > 0 && (
                 <VStack spacing="3" pb="3" align="left" maxHeight="300px" overflowY="scroll">
-                    {users.map((user, i) =>(
+                    {users.map((user, i) => (
                         <HStack key={i} pb="3" borderBottomWidth={i < _users.length - 1 ? 1 : 0} whiteSpace="nowrap">
                             <Text textOverflow="ellipsis" overflow="hidden">
                                 {_identity?.commitment === user ? <b>{user}</b> : user}
                             </Text>
                         </HStack>
-                        
                     ))}
                 </VStack>
             )}

--- a/apps/web-app/src/app/group/page.tsx
+++ b/apps/web-app/src/app/group/page.tsx
@@ -23,6 +23,8 @@ export default function GroupsPage() {
         }
     }, [_users, setLog])
 
+    const users = [..._users].reverse();
+
     const joinGroup = useCallback(async () => {
         if (!_identity) {
             return
@@ -130,12 +132,14 @@ export default function GroupsPage() {
 
             {_users.length > 0 && (
                 <VStack spacing="3" pb="3" align="left" maxHeight="300px" overflowY="scroll">
-                    {_users.map((user, i) => (
+                    {users.map((user, i) =>(
+                      
                         <HStack key={i} pb="3" borderBottomWidth={i < _users.length - 1 ? 1 : 0} whiteSpace="nowrap">
                             <Text textOverflow="ellipsis" overflow="hidden">
                                 {_identity?.commitment === user ? <b>{user}</b> : user}
                             </Text>
                         </HStack>
+                        
                     ))}
                 </VStack>
             )}

--- a/apps/web-app/src/app/proofs/page.tsx
+++ b/apps/web-app/src/app/proofs/page.tsx
@@ -25,6 +25,8 @@ export default function ProofsPage() {
         }
     }, [_feedback, setLog])
 
+    const feedback = [..._feedback].reverse();
+
     const sendFeedback = useCallback(async () => {
         if (!_identity) {
             return
@@ -161,7 +163,7 @@ export default function ProofsPage() {
 
             {_feedback.length > 0 && (
                 <VStack spacing="3" pb="3" align="left" maxHeight="300px" overflowY="scroll">
-                    {_feedback.map((f, i) => (
+                    {feedback.map((f, i) => (
                         <HStack key={i} pb="3" borderBottomWidth={i < _feedback.length - 1 ? 1 : 0}>
                             <Text>{f}</Text>
                         </HStack>

--- a/apps/web-app/src/app/proofs/page.tsx
+++ b/apps/web-app/src/app/proofs/page.tsx
@@ -8,7 +8,7 @@ import { Box, Button, Divider, Heading, HStack, Link, Text, useBoolean, VStack }
 import { generateProof, Group } from "@semaphore-protocol/core"
 import { encodeBytes32String, ethers } from "ethers"
 import { useRouter } from "next/navigation"
-import { useCallback, useEffect } from "react"
+import { useCallback, useEffect, useMemo } from "react"
 import Feedback from "../../../contract-artifacts/Feedback.json"
 import useSemaphoreIdentity from "@/hooks/useSemaphoreIdentity"
 
@@ -25,7 +25,7 @@ export default function ProofsPage() {
         }
     }, [_feedback, setLog])
 
-    const feedback = [..._feedback].reverse();
+    const feedback = useMemo(() => [..._feedback].reverse(), [_feedback])
 
     const sendFeedback = useCallback(async () => {
         if (!_identity) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request -->
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently you have to scroll down to view your recently added feedback or your id in the group.  So the fix is to reverse both the lists before rendering them on the UI.

## Related Issue
https://github.com/semaphore-protocol/boilerplate/issues/59

## Does this introduce a breaking change?
-    No




