### PR TITLE
Add Home link to header for easy navigation

### DIFF
--- a/apps/web-app/src/components/PageContainer.tsx
+++ b/apps/web-app/src/components/PageContainer.tsx
@@ -27,7 +27,16 @@ export default function PageContainer({
 
     return (
         <>
-            <HStack align="center" justify="right" p="2">
+            <HStack align="center" justify="space-evenly" p="2">
+            <Link
+                href="/"
+                ml="2"
+                textDecoration="none"
+                _hover={{ textDecoration: "none" }}
+                _focus={{ textDecoration: "none" }}
+            >
+                Feedback
+        </Link>
                 <Link
                     href={getExplorerLink(
                         process.env.NEXT_PUBLIC_DEFAULT_NETWORK as string,

--- a/apps/web-app/src/components/PageContainer.tsx
+++ b/apps/web-app/src/components/PageContainer.tsx
@@ -27,34 +27,38 @@ export default function PageContainer({
 
     return (
         <>
-            <HStack align="center" justify="space-evenly" p="2">
-            <Link
-                href="/"
-                ml="2"
-                textDecoration="none"
-                _hover={{ textDecoration: "none" }}
-                _focus={{ textDecoration: "none" }}
-            >
-                Feedback
-        </Link>
+            <HStack align="center" justify="space-between" p="2">
                 <Link
-                    href={getExplorerLink(
-                        process.env.NEXT_PUBLIC_DEFAULT_NETWORK as string,
-                        process.env.NEXT_PUBLIC_FEEDBACK_CONTRACT_ADDRESS as string
-                    )}
-                    isExternal
+                    href="/"
+                    ml="2"
+                    textDecoration="none"
+                    _hover={{ textDecoration: "none" }}
+                    _focus={{ textDecoration: "none" }}
                 >
-                    <Text>{shortenString(process.env.NEXT_PUBLIC_FEEDBACK_CONTRACT_ADDRESS as string, [6, 4])}</Text>
+                    Feedback
                 </Link>
-                <Link href="https://github.com/semaphore-protocol/boilerplate" isExternal>
-                    <IconButton
-                        aria-label="Github repository"
-                        variant="link"
-                        py="3"
-                        color="text.100"
-                        icon={<Icon boxSize={6} as={FaGithub} />}
-                    />
-                </Link>
+                <HStack>
+                    <Link
+                        href={getExplorerLink(
+                            process.env.NEXT_PUBLIC_DEFAULT_NETWORK as string,
+                            process.env.NEXT_PUBLIC_FEEDBACK_CONTRACT_ADDRESS as string
+                        )}
+                        isExternal
+                    >
+                        <Text>
+                            {shortenString(process.env.NEXT_PUBLIC_FEEDBACK_CONTRACT_ADDRESS as string, [6, 4])}
+                        </Text>
+                    </Link>
+                    <Link href="https://github.com/semaphore-protocol/boilerplate" isExternal>
+                        <IconButton
+                            aria-label="Github repository"
+                            variant="link"
+                            py="3"
+                            color="text.100"
+                            icon={<Icon boxSize={6} as={FaGithub} />}
+                        />
+                    </Link>
+                </HStack>
             </HStack>
 
             <Container maxW="xl" flex="1" display="flex" alignItems="center">


### PR DESCRIPTION
## Description

This PR adds a **Home link** to the header of the `PageContainer` component to make it easier for users to navigate back to the first page of the app. The link appears at the start of the header for quick access, improving user experience.

### Changes:
- Added a **Home** link in the header that redirects to the root page (`"/"`).
- Adjusted the header layout to maintain a clean, user-friendly interface.
- Ensured consistency with the existing design and layout elements.

## Context
Closes #74 – The issue highlighted the need to make it easier to go to the first page of the app, and this solution aligns with the approach used in the Semaphore templates.

## Screenshots 
![image](https://github.com/user-attachments/assets/f7e8d53a-c988-4892-a27d-be4b7546b7d4)


## Checklist:
- [x] Tested the Home link and ensured proper navigation.
- [x] Updated relevant components and ensured no styling issues.
