### PR TITLE
chore: update default network to hardhat if not specified in env

### DIFF
--- a/apps/contracts/hardhat.config.ts
+++ b/apps/contracts/hardhat.config.ts
@@ -52,7 +52,7 @@ function getNetworks(): NetworksUserConfig {
 
 const hardhatConfig: HardhatUserConfig = {
     solidity: "0.8.23",
-    defaultNetwork: process.env.DEFAULT_NETWORK || "localhost",
+    defaultNetwork: process.env.DEFAULT_NETWORK || "hardhat",
     networks: {
         hardhat: {
             chainId: 1337


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

Update default network to **hardhat** if not specified in env.

The reason of this change is because currently running `yarn test*` inside **apps/contracts** directory will fail as it expects a local hardhat node to be running. I believe running the test on in-memory hardhat node should be good enough.

@cedoor @vplasencia see if this suggestion is okay with you. Thanks.